### PR TITLE
Fix exception for SPI 0.1.

### DIFF
--- a/touch/src/main/java/eu/vranckaert/driver/touch/TouchScreenDriverService.java
+++ b/touch/src/main/java/eu/vranckaert/driver/touch/TouchScreenDriverService.java
@@ -1,5 +1,6 @@
 package eu.vranckaert.driver.touch;
 
+import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
@@ -30,6 +31,14 @@ public class TouchScreenDriverService extends Service {
 
         mDriver = mDriverProfile.getDriver();
         mDriver.run();
+
+        Notification notification = new Notification.Builder(getApplicationContext())
+                .setChannelId("touchscrenn_display")
+                .setContentTitle("Start touch screen")
+                .setContentText("Start touch screen driver as Service.")
+                .setSmallIcon(1)
+                .build();
+        startForeground(2,notification);
 
         return super.onStartCommand(intent, flags, startId);
     }

--- a/touch/src/main/java/eu/vranckaert/driver/touch/TouchScreenDriverService.java
+++ b/touch/src/main/java/eu/vranckaert/driver/touch/TouchScreenDriverService.java
@@ -55,7 +55,7 @@ public class TouchScreenDriverService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
-
+        stopForeground(true);
         if (mDriver != null) {
             mDriver.close();
         }


### PR DESCRIPTION
I success to running this driver on Android Things 1.0.1 .

At the version of Android O later ,  Android service that spawn from startForgroundService, need to run startForground method in Service::onStartCommand.
See in:
https://developer.android.com/about/versions/oreo/background

Sorry, it is separated two commit. You can rebase it.

Please check it and merger your repository.